### PR TITLE
Publish release checksums and verify setup action downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,22 @@ jobs:
 
       - name: Package
         run: |
-          tar -czf drift-${{ matrix.target }}.tar.gz -C zig-out/bin drift
+          TAR="drift-${{ matrix.target }}.tar.gz"
+          tar -czf "$TAR" -C zig-out/bin drift
+
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$TAR" | cut -d' ' -f1 > "$TAR.sha256"
+          else
+            shasum -a 256 "$TAR" | cut -d' ' -f1 > "$TAR.sha256"
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: drift-${{ matrix.target }}
-          path: drift-${{ matrix.target }}.tar.gz
+          path: |
+            drift-${{ matrix.target }}.tar.gz
+            drift-${{ matrix.target }}.tar.gz.sha256
 
   release:
     name: Create release
@@ -91,6 +100,8 @@ jobs:
           name: ${{ github.ref_name }}
           body: ${{ needs.generate-notes.outputs.body }}
           prerelease: false
-          files: drift-*.tar.gz
+          files: |
+            drift-*.tar.gz
+            drift-*.tar.gz.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ Any markdown file in your repo can declare anchors to code — specific files or
 ## Install
 
 ```bash
+curl -fsSL https://drift.fp.dev/install.sh | sh
+```
+
+To install a specific version:
+
+```bash
+curl -fsSL https://drift.fp.dev/install.sh | sh -s -- --version v0.1.0
+```
+
+Or build from source:
+
+```bash
 zig build -Doptimize=ReleaseSafe --prefix ~/.local
 ```
 
@@ -25,7 +37,7 @@ zig build -Doptimize=ReleaseSafe --prefix ~/.local
 Install the CLI and the agent skill:
 
 ```bash
-zig build -Doptimize=ReleaseSafe --prefix ~/.local
+curl -fsSL https://drift.fp.dev/install.sh | sh
 npx skills add fiberplane/drift
 ```
 
@@ -147,7 +159,7 @@ jobs:
       - run: drift lint
 ```
 
-`fetch-depth: 0` is required — drift needs VCS history to compare content at provenance revisions. The setup action auto-detects platform and downloads the right binary from GitHub releases.
+`fetch-depth: 0` is required — drift needs VCS history to compare content at provenance revisions. The setup action auto-detects platform, downloads the right binary from GitHub releases, and verifies its checksum before installing.
 
 ## VCS support
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Setup Drift
-description: Install the drift CLI for spec-to-code staleness checking
+description: Install the drift CLI for spec-to-code staleness checking with checksum verification
 inputs:
   version:
     description: Release tag to install (e.g. "v0.1.0"). Defaults to latest.
@@ -41,8 +41,32 @@ runs:
     - name: Download and install
       shell: bash
       run: |
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+
         URL="https://github.com/fiberplane/drift/releases/download/${{ steps.version.outputs.tag }}/drift-${{ steps.platform.outputs.target }}.tar.gz"
-        curl -fsSL "$URL" | tar xz -C /usr/local/bin
+        CHECKSUM_URL="${URL}.sha256"
+        ARCHIVE_PATH="$TMP_DIR/drift.tar.gz"
+        CHECKSUM_PATH="$TMP_DIR/drift.tar.gz.sha256"
+
+        curl -fsSL "$URL" -o "$ARCHIVE_PATH"
+        curl -fsSL "$CHECKSUM_URL" -o "$CHECKSUM_PATH"
+
+        EXPECTED_CHECKSUM=$(tr -d '[:space:]' < "$CHECKSUM_PATH")
+        if command -v sha256sum >/dev/null 2>&1; then
+          ACTUAL_CHECKSUM=$(sha256sum "$ARCHIVE_PATH" | cut -d' ' -f1)
+        else
+          ACTUAL_CHECKSUM=$(shasum -a 256 "$ARCHIVE_PATH" | cut -d' ' -f1)
+        fi
+
+        if [ "$ACTUAL_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
+          echo "::error::Checksum verification failed for drift download"
+          echo "Expected: $EXPECTED_CHECKSUM"
+          echo "Actual:   $ACTUAL_CHECKSUM"
+          exit 1
+        fi
+
+        tar -xzf "$ARCHIVE_PATH" -C /usr/local/bin
         chmod +x /usr/local/bin/drift
         drift --help > /dev/null 2>&1 || true
         echo "Installed drift ${{ steps.version.outputs.tag }} (${{ steps.platform.outputs.target }})"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,7 +42,7 @@ Types `chore`, `style`, and `ci` are excluded from changelogs. Merge commits are
 3. The tag push triggers `.github/workflows/release.yml`, which:
    - Generates release notes with git-cliff (grouped by Features, Bug Fixes, Documentation, Refactor)
    - Cross-compiles for all 4 targets with Zig 0.15.2
-   - Creates a GitHub release with the generated notes and all tarballs attached
+   - Creates a GitHub release with the generated notes, all tarballs, and matching `.sha256` checksum files attached
 
 ### CHANGELOG.md
 


### PR DESCRIPTION
## Summary
- publish `.sha256` files alongside each release tarball
- verify release checksums in the composite setup action before installing
- document the new hosted installer entrypoint in the README

Paired with fiberplane/nocturne#598 for the shared `drift.fp.dev` installer + redirect layer.

## Testing
- parsed `.github/workflows/release.yml` and `action.yml`
