### PR TITLE
Inject release version into drift binary

### DIFF
--- a/.claude/skills/drift/SKILL.md
+++ b/.claude/skills/drift/SKILL.md
@@ -3,10 +3,10 @@ name: drift
 description: Drift spec-to-code anchor conventions. Use when editing code that is bound by drift specs, updating specs, working with drift frontmatter, or when drift check reports stale anchors.
 drift:
   files:
-    - src/main.zig@a7ffa398
-    - src/frontmatter.zig@a7ffa398
-    - src/scanner.zig@a7ffa398
-    - src/vcs.zig@a7ffa398
+    - src/main.zig@2d3a4080
+    - src/frontmatter.zig@2d3a4080
+    - src/scanner.zig@2d3a4080
+    - src/vcs.zig@2d3a4080
 ---
 
 # Drift

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           version: 0.15.2
 
       - name: Build
-        run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.zig-target }} ${{ matrix.zig-cpu && format('-Dcpu={0}', matrix.zig-cpu) || '' }}
+        run: zig build -Doptimize=ReleaseSafe -Dversion=${{ github.ref_name }} -Dtarget=${{ matrix.zig-target }} ${{ matrix.zig-cpu && format('-Dcpu={0}', matrix.zig-cpu) || '' }}
 
       - name: Package
         run: |

--- a/README.md
+++ b/README.md
@@ -11,9 +11,22 @@ Any markdown file in your repo can declare anchors to code — specific files or
 curl -fsSL https://drift.fp.dev/install.sh | sh
 ```
 
+To install a specific version:
+
+```bash
+curl -fsSL https://drift.fp.dev/install.sh | sh -s -- --version vX.Y.Z
+```
+
+Or build from source:
+
+```bash
+zig build -Doptimize=ReleaseSafe --prefix ~/.local
+```
+
 ### Coding agent skill (Claude Code, Codex)
 
 ```bash
+curl -fsSL https://drift.fp.dev/install.sh | sh
 npx skills add fiberplane/drift
 ```
 

--- a/build.zig
+++ b/build.zig
@@ -3,12 +3,16 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const version = b.option([]const u8, "version", "Drift version string") orelse "0.0.0-dev";
 
     // Dependencies
     const clap_dep = b.dependency("clap", .{});
 
     // Build tree-sitter C library from vendor sources
     const ts_module = buildTreeSitter(b, target, optimize);
+
+    const build_options = b.addOptions();
+    build_options.addOption([]const u8, "version", version);
 
     // Root module
     const root_module = b.createModule(.{
@@ -21,6 +25,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "tree_sitter", .module = ts_module },
         },
     });
+    root_module.addOptions("build_options", build_options);
     linkGrammars(b, root_module);
 
     // Executable

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,7 +1,7 @@
 ---
 drift:
   files:
-    - src/main.zig@a7ffa398
+    - src/main.zig@2d3a4080
 ---
 
 # CLI Reference

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,9 +1,9 @@
 ---
 drift:
   files:
-    - src/main.zig@a7ffa398
-    - src/symbols.zig@a7ffa398
-    - src/vcs.zig@a7ffa398
+    - src/main.zig@2d3a4080
+    - src/symbols.zig@2d3a4080
+    - src/vcs.zig@2d3a4080
 ---
 
 # Decisions

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,11 +1,11 @@
 ---
 drift:
   files:
-    - src/main.zig@a7ffa398
-    - src/frontmatter.zig@a7ffa398
-    - src/scanner.zig@a7ffa398
-    - src/symbols.zig@a7ffa398
-    - src/vcs.zig@a7ffa398
+    - src/main.zig@2d3a4080
+    - src/frontmatter.zig@2d3a4080
+    - src/scanner.zig@2d3a4080
+    - src/symbols.zig@2d3a4080
+    - src/vcs.zig@2d3a4080
 ---
 
 # Design

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,9 +1,9 @@
 ---
 drift:
   files:
-    - .github/workflows/release.yml@xxoutkyz
-    - .github/workflows/ci.yml@xxoutkyz
-    - cliff.toml@xxoutkyz
+    - .github/workflows/release.yml@2d3a4080
+    - .github/workflows/ci.yml@2d3a4080
+    - cliff.toml@2d3a4080
 ---
 
 # Releasing

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const build_options = @import("build_options");
 const clap = @import("clap");
 const frontmatter = @import("frontmatter.zig");
 const scanner = @import("scanner.zig");
@@ -7,7 +8,7 @@ const vcs = @import("vcs.zig");
 
 const Spec = scanner.Spec;
 
-const version = "0.1.0";
+const version = build_options.version;
 
 const SubCommand = enum {
     check,


### PR DESCRIPTION
## Summary
- replace the hardcoded `0.1.0` CLI version with a build option
- inject `${{ github.ref_name }}` into release builds so release binaries report the release tag
- change the README example to use a generic `vX.Y.Z` placeholder

## Notes
The public installer/redirect flow is working correctly. The bug is that the released binary itself still prints `drift 0.1.0` because `src/main.zig` had a stale hardcoded version string.

## Testing
- parsed `.github/workflows/release.yml`
- local `zig build` validation is blocked by linker issues in this environment, so GitHub CI will be the real build check
