### PR TITLE
fix(hooks): unset GIT_DIR in pre-push so integration tests don't inherit it

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+# git sets GIT_DIR when invoking hooks; unset it so integration tests that
+# spawn `git` inside temp repos don't accidentally operate on this repo's .git.
+unset GIT_DIR
+
 echo "pre-push: building drift..."
 zig build -Doptimize=ReleaseSafe
 


### PR DESCRIPTION
When `git push` invokes `hooks/pre-push`, git sets `GIT_DIR=.git` in the env. That env var leaks into `zig build test`, and into every subprocess it spawns — including the `git` commands that integration tests run against temp repos (via `helpers.TempRepo`). With `GIT_DIR` set, those subprocess `git` calls operate on *this* repo's `.git` instead of the test's temp directory, which breaks at least one test (`check from nested subdir with its own drift.lock only checks that scope` expected exit 1, got 0).

The hook passes when run directly but fails under `git push`. This mismatch hit me while cutting the v0.9.0 release.

Fix: unset `GIT_DIR` at the top of the hook.